### PR TITLE
feat: プロジェクト一覧表示と新規作成機能

### DIFF
--- a/src/app/(dashboard)/projects/actions.ts
+++ b/src/app/(dashboard)/projects/actions.ts
@@ -1,0 +1,80 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { z } from "zod";
+import { createClient } from "@/lib/supabase/server";
+
+const createProjectSchema = z.object({
+  name: z
+    .string()
+    .min(1, "プロジェクト名を入力してください")
+    .max(100, "プロジェクト名は100文字以内で入力してください"),
+  description: z
+    .string()
+    .max(500, "説明は500文字以内で入力してください")
+    .optional()
+    .transform((val) => val || null),
+});
+
+export interface CreateProjectState {
+  error?: string;
+  fieldErrors?: {
+    name?: string[];
+    description?: string[];
+  };
+  success?: boolean;
+}
+
+export async function createProject(
+  _prevState: CreateProjectState,
+  formData: FormData,
+): Promise<CreateProjectState> {
+  const rawFormData = {
+    name: formData.get("name") as string,
+    description: formData.get("description") as string,
+  };
+
+  const validatedFields = createProjectSchema.safeParse(rawFormData);
+
+  if (!validatedFields.success) {
+    return {
+      fieldErrors: validatedFields.error.flatten().fieldErrors,
+    };
+  }
+
+  try {
+    const supabase = await createClient();
+
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user) {
+      return {
+        error: "認証が必要です。ログインしてください。",
+      };
+    }
+
+    const { error } = await supabase.from("projects").insert({
+      name: validatedFields.data.name,
+      description: validatedFields.data.description,
+      owner_id: user.id,
+    });
+
+    if (error) {
+      return {
+        error: "プロジェクトの作成に失敗しました。もう一度お試しください。",
+      };
+    }
+
+    revalidatePath("/projects");
+
+    return {
+      success: true,
+    };
+  } catch {
+    return {
+      error: "予期しないエラーが発生しました。もう一度お試しください。",
+    };
+  }
+}

--- a/src/app/(dashboard)/projects/error.tsx
+++ b/src/app/(dashboard)/projects/error.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { useEffect } from "react";
+import { Button } from "@/components/ui";
+
+export default function ProjectsError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    // eslint-disable-next-line no-console
+    console.error("Projects error:", error);
+  }, [error]);
+
+  return (
+    <div className="flex h-64 flex-col items-center justify-center gap-4">
+      <h2 className="text-lg font-semibold text-gray-900">
+        プロジェクトの読み込みに失敗しました
+      </h2>
+      <p className="text-sm text-gray-600">
+        データの取得中にエラーが発生しました。もう一度お試しください。
+      </p>
+      <Button onClick={reset}>再試行</Button>
+    </div>
+  );
+}

--- a/src/app/(dashboard)/projects/loading.tsx
+++ b/src/app/(dashboard)/projects/loading.tsx
@@ -1,0 +1,31 @@
+function SkeletonCard() {
+  return (
+    <div className="animate-pulse rounded-xl bg-white p-4 shadow-sm">
+      <div className="flex items-start gap-3">
+        <div className="h-8 w-8 flex-shrink-0 rounded bg-gray-200" />
+        <div className="flex-1 space-y-2">
+          <div className="h-5 w-3/4 rounded bg-gray-200" />
+          <div className="h-4 w-full rounded bg-gray-200" />
+          <div className="h-3 w-1/4 rounded bg-gray-200" />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function ProjectsLoading() {
+  return (
+    <div>
+      <div className="mb-6 flex items-center justify-between">
+        <div className="h-9 w-48 animate-pulse rounded bg-gray-200" />
+        <div className="h-9 w-24 animate-pulse rounded-lg bg-gray-200" />
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        <SkeletonCard />
+        <SkeletonCard />
+        <SkeletonCard />
+      </div>
+    </div>
+  );
+}

--- a/src/app/(dashboard)/projects/page.tsx
+++ b/src/app/(dashboard)/projects/page.tsx
@@ -1,33 +1,51 @@
-import Link from "next/link";
-import { FolderIcon } from "@/components/icons";
+import { redirect } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+import type { Project } from "@/types";
+import ProjectCard from "@/components/projects/ProjectCard";
+import EmptyState from "@/components/projects/EmptyState";
+import CreateProjectModal from "@/components/projects/CreateProjectModal";
 
-const mockProjects = [
-  { id: "1", name: "サンプルプロジェクト", description: "これはサンプルです" },
-  { id: "2", name: "開発タスク", description: "開発関連のタスク管理" },
-];
+export const dynamic = "force-dynamic";
 
-export default function ProjectsPage() {
+export default async function ProjectsPage() {
+  const supabase = await createClient();
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect("/login");
+  }
+
+  const { data: projects, error } = await supabase
+    .from("projects")
+    .select("*")
+    .eq("owner_id", user.id)
+    .order("created_at", { ascending: false });
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  const typedProjects = (projects ?? []) as Project[];
+
   return (
     <div>
-      <h1 className="mb-6 text-3xl font-bold">プロジェクト</h1>
-
-      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-        {mockProjects.map((project) => (
-          <Link
-            key={project.id}
-            href={`/projects/${project.id}`}
-            className="block rounded-xl bg-white p-4 shadow-sm transition-shadow hover:shadow-md"
-          >
-            <div className="flex items-start gap-3">
-              <FolderIcon className="h-8 w-8 text-indigo-500" />
-              <div>
-                <h2 className="text-lg font-semibold">{project.name}</h2>
-                <p className="text-sm text-gray-600">{project.description}</p>
-              </div>
-            </div>
-          </Link>
-        ))}
+      <div className="mb-6 flex items-center justify-between">
+        <h1 className="text-3xl font-bold">プロジェクト</h1>
+        <CreateProjectModal />
       </div>
+
+      {typedProjects.length === 0 ? (
+        <EmptyState />
+      ) : (
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {typedProjects.map((project) => (
+            <ProjectCard key={project.id} project={project} />
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/icons/index.tsx
+++ b/src/components/icons/index.tsx
@@ -140,6 +140,25 @@ export function UserIcon({ className }: IconProps) {
   );
 }
 
+export function XMarkIcon({ className }: IconProps) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+      className={className}
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M6 18 18 6M6 6l12 12"
+      />
+    </svg>
+  );
+}
+
 export function LogoutIcon({ className }: IconProps) {
   return (
     <svg

--- a/src/components/projects/CreateProjectModal.tsx
+++ b/src/components/projects/CreateProjectModal.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import { useEffect, useRef, useState, useCallback } from "react";
+import { useFormState } from "react-dom";
+import { PlusIcon, XMarkIcon } from "@/components/icons";
+import { FormInput, SubmitButton, Alert } from "@/components/ui";
+import {
+  createProject,
+  type CreateProjectState,
+} from "@/app/(dashboard)/projects/actions";
+
+const initialState: CreateProjectState = {};
+
+export default function CreateProjectModal() {
+  const [isOpen, setIsOpen] = useState(false);
+  const [state, formAction] = useFormState(createProject, initialState);
+  const formRef = useRef<HTMLFormElement>(null);
+
+  const closeModal = useCallback(() => {
+    setIsOpen(false);
+  }, []);
+
+  // 成功時にモーダルを閉じてフォームをリセット
+  useEffect(() => {
+    if (state.success) {
+      closeModal();
+      formRef.current?.reset();
+    }
+  }, [state.success, closeModal]);
+
+  // Escape キーでモーダルを閉じる
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") {
+        closeModal();
+      }
+    }
+
+    if (isOpen) {
+      document.addEventListener("keydown", handleKeyDown);
+      return () => document.removeEventListener("keydown", handleKeyDown);
+    }
+  }, [isOpen, closeModal]);
+
+  return (
+    <>
+      <button
+        onClick={() => setIsOpen(true)}
+        className="flex items-center gap-2 rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-indigo-700"
+      >
+        <PlusIcon className="h-4 w-4" />
+        新規作成
+      </button>
+
+      {isOpen && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center">
+          {/* オーバーレイ */}
+          <div
+            className="absolute inset-0 bg-black/50 transition-opacity"
+            onClick={closeModal}
+            aria-hidden="true"
+          />
+
+          {/* モーダルカード */}
+          <div className="relative w-full max-w-md rounded-xl bg-white p-6 shadow-xl">
+            {/* ヘッダー */}
+            <div className="mb-4 flex items-center justify-between">
+              <h2 className="text-lg font-semibold">新規プロジェクト</h2>
+              <button
+                onClick={closeModal}
+                className="rounded-lg p-1 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600"
+              >
+                <XMarkIcon className="h-5 w-5" />
+              </button>
+            </div>
+
+            {/* フォーム */}
+            <form ref={formRef} action={formAction} className="space-y-4">
+              <FormInput
+                label="プロジェクト名"
+                name="name"
+                required
+                placeholder="例: マイプロジェクト"
+                error={state.fieldErrors?.name?.[0]}
+              />
+
+              <div>
+                <label
+                  htmlFor="description"
+                  className="block text-sm font-medium text-gray-700"
+                >
+                  説明（任意）
+                </label>
+                <textarea
+                  id="description"
+                  name="description"
+                  rows={3}
+                  placeholder="プロジェクトの説明を入力..."
+                  className="mt-1 block w-full rounded-lg border border-gray-300 px-3 py-2 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+                />
+                {state.fieldErrors?.description?.[0] && (
+                  <p className="mt-1 text-sm text-red-600">
+                    {state.fieldErrors.description[0]}
+                  </p>
+                )}
+              </div>
+
+              {state.error && <Alert variant="error">{state.error}</Alert>}
+
+              <div className="flex justify-end gap-3 pt-2">
+                <button
+                  type="button"
+                  onClick={closeModal}
+                  className="rounded-lg px-4 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-100"
+                >
+                  キャンセル
+                </button>
+                <SubmitButton size="sm" pendingText="作成中...">
+                  作成
+                </SubmitButton>
+              </div>
+            </form>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/components/projects/EmptyState.tsx
+++ b/src/components/projects/EmptyState.tsx
@@ -1,0 +1,15 @@
+import { FolderIcon } from "@/components/icons";
+
+export default function EmptyState() {
+  return (
+    <div className="flex flex-col items-center justify-center rounded-xl border-2 border-dashed border-gray-300 py-16">
+      <FolderIcon className="h-12 w-12 text-gray-400" />
+      <h3 className="mt-4 text-lg font-medium text-gray-900">
+        プロジェクトがまだありません
+      </h3>
+      <p className="mt-2 text-sm text-gray-500">
+        最初のプロジェクトを作成して、タスク管理を始めましょう
+      </p>
+    </div>
+  );
+}

--- a/src/components/projects/ProjectCard.tsx
+++ b/src/components/projects/ProjectCard.tsx
@@ -1,0 +1,55 @@
+import Link from "next/link";
+import { FolderIcon } from "@/components/icons";
+import type { Project } from "@/types";
+
+interface ProjectCardProps {
+  project: Project;
+}
+
+function formatRelativeTime(dateString: string): string {
+  const date = new Date(dateString);
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffSeconds = Math.floor(diffMs / 1000);
+  const diffMinutes = Math.floor(diffSeconds / 60);
+  const diffHours = Math.floor(diffMinutes / 60);
+  const diffDays = Math.floor(diffHours / 24);
+
+  if (diffDays > 30) {
+    return date.toLocaleDateString("ja-JP");
+  }
+  if (diffDays > 0) {
+    return `${diffDays}日前`;
+  }
+  if (diffHours > 0) {
+    return `${diffHours}時間前`;
+  }
+  if (diffMinutes > 0) {
+    return `${diffMinutes}分前`;
+  }
+  return "たった今";
+}
+
+export default function ProjectCard({ project }: ProjectCardProps) {
+  return (
+    <Link
+      href={`/projects/${project.id}`}
+      className="block rounded-xl bg-white p-4 shadow-sm transition-shadow hover:shadow-md"
+    >
+      <div className="flex items-start gap-3">
+        <FolderIcon className="h-8 w-8 flex-shrink-0 text-indigo-500" />
+        <div className="min-w-0 flex-1">
+          <h2 className="truncate text-lg font-semibold">{project.name}</h2>
+          {project.description && (
+            <p className="mt-1 line-clamp-2 text-sm text-gray-600">
+              {project.description}
+            </p>
+          )}
+          <p className="mt-2 text-xs text-gray-400">
+            {formatRelativeTime(project.created_at)}
+          </p>
+        </div>
+      </div>
+    </Link>
+  );
+}


### PR DESCRIPTION
## 概要

Phase 3 の最初のステップとして、プロジェクト一覧表示と新規作成機能を実装。
モックデータを Supabase からの実データ取得に置き換え、モーダル形式のプロジェクト作成 UI を追加。

## 変更点

- **プロジェクト一覧** (`projects/page.tsx`): モックデータ → Supabase 実データ取得（Server Component + `force-dynamic`）
- **プロジェクト作成** (`projects/actions.ts`): Server Action + Zod バリデーション（名前必須/100文字制限、説明任意/500文字制限）
- **作成モーダル** (`CreateProjectModal.tsx`): useFormState パターン、Escape/オーバーレイ閉じ対応
- **ProjectCard** (`ProjectCard.tsx`): カード表示コンポーネント（相対時間表示付き）
- **EmptyState** (`EmptyState.tsx`): プロジェクト 0 件時の空状態 UI
- **Loading UI** (`projects/loading.tsx`): スケルトンローダー（カード 3 枚分）
- **Error Boundary** (`projects/error.tsx`): エラー表示 + 再試行ボタン
- **XMarkIcon**: モーダル閉じボタン用アイコン追加

## 設計書

`.claude/docs/design-project-list-create.md`

## テストプラン

### 自動チェック（AI 確認済み）
- [x] ESLint: エラーなし
- [x] TypeScript ビルド: 成功
- [x] セキュリティチェック: 秘匿情報・個人情報の混入なし

### 手動チェック（マージ前にユーザー確認）
- [x] ログイン後、`/projects` でプロジェクト一覧が表示される
- [x] プロジェクトが 0 件の場合、空状態 UI が表示される
- [x] 「新規作成」ボタンでモーダルが開く
- [x] プロジェクト名を入力して作成できる
- [x] バリデーションエラーが表示される（名前空、100文字超）
- [x] 作成後、一覧に新しいプロジェクトが表示される
- [x] モーダルをキャンセル/オーバーレイクリック/Escape で閉じられる

Closes #1
