### PR TITLE
feat: Phase 4 タスク CRUD 機能

### DIFF
--- a/src/app/(dashboard)/projects/[projectId]/actions.ts
+++ b/src/app/(dashboard)/projects/[projectId]/actions.ts
@@ -1,0 +1,228 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { z } from "zod";
+import { createClient } from "@/lib/supabase/server";
+
+// --- Zod Schemas ---
+
+const createTaskSchema = z.object({
+  title: z
+    .string()
+    .min(1, "タイトルを入力してください")
+    .max(200, "タイトルは200文字以内で入力してください"),
+  description: z
+    .string()
+    .max(1000, "説明は1000文字以内で入力してください")
+    .optional()
+    .transform((val) => val || null),
+  status: z.enum(["todo", "in_progress", "done"]).default("todo"),
+  priority: z.enum(["low", "medium", "high"]).default("medium"),
+});
+
+const updateTaskSchema = z.object({
+  title: z
+    .string()
+    .min(1, "タイトルを入力してください")
+    .max(200, "タイトルは200文字以内で入力してください"),
+  description: z
+    .string()
+    .max(1000, "説明は1000文字以内で入力してください")
+    .optional()
+    .transform((val) => val || null),
+  status: z.enum(["todo", "in_progress", "done"]),
+  priority: z.enum(["low", "medium", "high"]),
+});
+
+// --- State Types ---
+
+export interface CreateTaskState {
+  error?: string;
+  fieldErrors?: {
+    title?: string[];
+    description?: string[];
+    status?: string[];
+    priority?: string[];
+  };
+  success?: boolean;
+}
+
+export interface UpdateTaskState {
+  error?: string;
+  fieldErrors?: {
+    title?: string[];
+    description?: string[];
+    status?: string[];
+    priority?: string[];
+  };
+  success?: boolean;
+}
+
+export interface DeleteTaskState {
+  error?: string;
+  success?: boolean;
+}
+
+// --- Server Actions ---
+
+export async function createTask(
+  _prevState: CreateTaskState,
+  formData: FormData,
+): Promise<CreateTaskState> {
+  const projectId = formData.get("projectId") as string;
+  const rawFormData = {
+    title: formData.get("title") as string,
+    description: formData.get("description") as string,
+    status: formData.get("status") as string,
+    priority: formData.get("priority") as string,
+  };
+
+  const validatedFields = createTaskSchema.safeParse(rawFormData);
+
+  if (!validatedFields.success) {
+    return {
+      fieldErrors: validatedFields.error.flatten().fieldErrors,
+    };
+  }
+
+  try {
+    const supabase = await createClient();
+
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user) {
+      return {
+        error: "認証が必要です。ログインしてください。",
+      };
+    }
+
+    const { error } = await supabase.from("tasks").insert({
+      title: validatedFields.data.title,
+      description: validatedFields.data.description,
+      status: validatedFields.data.status,
+      priority: validatedFields.data.priority,
+      project_id: projectId,
+      created_by: user.id,
+    });
+
+    if (error) {
+      return {
+        error: "タスクの作成に失敗しました。もう一度お試しください。",
+      };
+    }
+
+    revalidatePath(`/projects/${projectId}`);
+
+    return {
+      success: true,
+    };
+  } catch {
+    return {
+      error: "予期しないエラーが発生しました。もう一度お試しください。",
+    };
+  }
+}
+
+export async function updateTask(
+  _prevState: UpdateTaskState,
+  formData: FormData,
+): Promise<UpdateTaskState> {
+  const taskId = formData.get("taskId") as string;
+  const projectId = formData.get("projectId") as string;
+  const rawFormData = {
+    title: formData.get("title") as string,
+    description: formData.get("description") as string,
+    status: formData.get("status") as string,
+    priority: formData.get("priority") as string,
+  };
+
+  const validatedFields = updateTaskSchema.safeParse(rawFormData);
+
+  if (!validatedFields.success) {
+    return {
+      fieldErrors: validatedFields.error.flatten().fieldErrors,
+    };
+  }
+
+  try {
+    const supabase = await createClient();
+
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user) {
+      return {
+        error: "認証が必要です。ログインしてください。",
+      };
+    }
+
+    const { error } = await supabase
+      .from("tasks")
+      .update({
+        title: validatedFields.data.title,
+        description: validatedFields.data.description,
+        status: validatedFields.data.status,
+        priority: validatedFields.data.priority,
+      })
+      .eq("id", taskId);
+
+    if (error) {
+      return {
+        error: "タスクの更新に失敗しました。もう一度お試しください。",
+      };
+    }
+
+    revalidatePath(`/projects/${projectId}`);
+
+    return {
+      success: true,
+    };
+  } catch {
+    return {
+      error: "予期しないエラーが発生しました。もう一度お試しください。",
+    };
+  }
+}
+
+export async function deleteTask(
+  _prevState: DeleteTaskState,
+  formData: FormData,
+): Promise<DeleteTaskState> {
+  const taskId = formData.get("taskId") as string;
+  const projectId = formData.get("projectId") as string;
+
+  try {
+    const supabase = await createClient();
+
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user) {
+      return {
+        error: "認証が必要です。ログインしてください。",
+      };
+    }
+
+    const { error } = await supabase.from("tasks").delete().eq("id", taskId);
+
+    if (error) {
+      return {
+        error: "タスクの削除に失敗しました。もう一度お試しください。",
+      };
+    }
+
+    revalidatePath(`/projects/${projectId}`);
+
+    return {
+      success: true,
+    };
+  } catch {
+    return {
+      error: "予期しないエラーが発生しました。もう一度お試しください。",
+    };
+  }
+}

--- a/src/app/(dashboard)/projects/[projectId]/page.tsx
+++ b/src/app/(dashboard)/projects/[projectId]/page.tsx
@@ -3,31 +3,15 @@ import { redirect, notFound } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
 import { ListIcon, KanbanIcon } from "@/components/icons";
 import ProjectDetailActions from "@/components/projects/ProjectDetailActions";
-import type { Project } from "@/types";
+import CreateTaskModal from "@/components/tasks/CreateTaskModal";
+import TaskList from "@/components/tasks/TaskList";
+import type { Project, Task } from "@/types";
 
 export const dynamic = "force-dynamic";
 
 interface Props {
   params: { projectId: string };
 }
-
-const mockTasks = [
-  { id: "1", title: "タスク1", status: "todo", priority: "high" },
-  { id: "2", title: "タスク2", status: "in_progress", priority: "medium" },
-  { id: "3", title: "タスク3", status: "done", priority: "low" },
-];
-
-const statusLabels: Record<string, string> = {
-  todo: "未着手",
-  in_progress: "進行中",
-  done: "完了",
-};
-
-const priorityColors: Record<string, string> = {
-  high: "border-red-500 text-red-600",
-  medium: "border-yellow-500 text-yellow-600",
-  low: "border-green-500 text-green-600",
-};
 
 export default async function ProjectDetailPage({ params }: Props) {
   const { projectId } = params;
@@ -54,6 +38,14 @@ export default async function ProjectDetailPage({ params }: Props) {
 
   const typedProject = project as Project;
 
+  const { data: tasks } = await supabase
+    .from("tasks")
+    .select("*")
+    .eq("project_id", projectId)
+    .order("created_at", { ascending: false });
+
+  const typedTasks = (tasks ?? []) as Task[];
+
   return (
     <div>
       <div className="mb-6 flex items-center justify-between">
@@ -65,6 +57,7 @@ export default async function ProjectDetailPage({ params }: Props) {
         </div>
         <div className="flex items-center gap-2">
           <ProjectDetailActions project={typedProject} />
+          <CreateTaskModal projectId={projectId} />
           <button
             disabled
             className="flex items-center gap-2 rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white"
@@ -82,24 +75,7 @@ export default async function ProjectDetailPage({ params }: Props) {
         </div>
       </div>
 
-      <div className="space-y-2">
-        {mockTasks.map((task) => (
-          <div
-            key={task.id}
-            className="flex items-center gap-4 rounded-lg bg-white p-4 shadow-sm"
-          >
-            <span className="flex-1">{task.title}</span>
-            <span className="rounded-full bg-gray-100 px-3 py-1 text-sm">
-              {statusLabels[task.status]}
-            </span>
-            <span
-              className={`rounded-full border px-3 py-1 text-sm ${priorityColors[task.priority]}`}
-            >
-              {task.priority}
-            </span>
-          </div>
-        ))}
-      </div>
+      <TaskList tasks={typedTasks} projectId={projectId} />
     </div>
   );
 }

--- a/src/components/tasks/CreateTaskModal.tsx
+++ b/src/components/tasks/CreateTaskModal.tsx
@@ -1,0 +1,184 @@
+"use client";
+
+import { useEffect, useRef, useState, useCallback } from "react";
+import { useFormState } from "react-dom";
+import { PlusIcon, XMarkIcon } from "@/components/icons";
+import { FormInput, SubmitButton, Alert } from "@/components/ui";
+import {
+  createTask,
+  type CreateTaskState,
+} from "@/app/(dashboard)/projects/[projectId]/actions";
+
+const initialState: CreateTaskState = {};
+
+interface CreateTaskModalProps {
+  projectId: string;
+}
+
+export default function CreateTaskModal({ projectId }: CreateTaskModalProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [state, formAction] = useFormState(createTask, initialState);
+  const formRef = useRef<HTMLFormElement>(null);
+
+  const closeModal = useCallback(() => {
+    setIsOpen(false);
+  }, []);
+
+  // 成功時にモーダルを閉じてフォームをリセット
+  useEffect(() => {
+    if (state.success) {
+      closeModal();
+      formRef.current?.reset();
+    }
+  }, [state.success, closeModal]);
+
+  // Escape キーでモーダルを閉じる
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") {
+        closeModal();
+      }
+    }
+
+    if (isOpen) {
+      document.addEventListener("keydown", handleKeyDown);
+      return () => document.removeEventListener("keydown", handleKeyDown);
+    }
+  }, [isOpen, closeModal]);
+
+  return (
+    <>
+      <button
+        onClick={() => setIsOpen(true)}
+        className="flex items-center gap-2 rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-indigo-700"
+      >
+        <PlusIcon className="h-4 w-4" />
+        新規タスク
+      </button>
+
+      {isOpen && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center">
+          {/* オーバーレイ */}
+          <div
+            className="absolute inset-0 bg-black/50 transition-opacity"
+            onClick={closeModal}
+            aria-hidden="true"
+          />
+
+          {/* モーダルカード */}
+          <div className="relative w-full max-w-md rounded-xl bg-white p-6 shadow-xl">
+            {/* ヘッダー */}
+            <div className="mb-4 flex items-center justify-between">
+              <h2 className="text-lg font-semibold">新規タスク</h2>
+              <button
+                onClick={closeModal}
+                className="rounded-lg p-1 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600"
+              >
+                <XMarkIcon className="h-5 w-5" />
+              </button>
+            </div>
+
+            {/* フォーム */}
+            <form ref={formRef} action={formAction} className="space-y-4">
+              <input type="hidden" name="projectId" value={projectId} />
+
+              <FormInput
+                label="タイトル"
+                name="title"
+                required
+                placeholder="例: デザインレビュー"
+                error={state.fieldErrors?.title?.[0]}
+              />
+
+              <div>
+                <label
+                  htmlFor="create-task-description"
+                  className="block text-sm font-medium text-gray-700"
+                >
+                  説明（任意）
+                </label>
+                <textarea
+                  id="create-task-description"
+                  name="description"
+                  rows={3}
+                  placeholder="タスクの説明を入力..."
+                  className="mt-1 block w-full rounded-lg border border-gray-300 px-3 py-2 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+                />
+                {state.fieldErrors?.description?.[0] && (
+                  <p className="mt-1 text-sm text-red-600">
+                    {state.fieldErrors.description[0]}
+                  </p>
+                )}
+              </div>
+
+              <div className="grid grid-cols-2 gap-4">
+                <div>
+                  <label
+                    htmlFor="create-task-status"
+                    className="block text-sm font-medium text-gray-700"
+                  >
+                    ステータス
+                  </label>
+                  <select
+                    id="create-task-status"
+                    name="status"
+                    defaultValue="todo"
+                    className="mt-1 block w-full rounded-lg border border-gray-300 px-3 py-2 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+                  >
+                    <option value="todo">未着手</option>
+                    <option value="in_progress">進行中</option>
+                    <option value="done">完了</option>
+                  </select>
+                  {state.fieldErrors?.status?.[0] && (
+                    <p className="mt-1 text-sm text-red-600">
+                      {state.fieldErrors.status[0]}
+                    </p>
+                  )}
+                </div>
+
+                <div>
+                  <label
+                    htmlFor="create-task-priority"
+                    className="block text-sm font-medium text-gray-700"
+                  >
+                    優先度
+                  </label>
+                  <select
+                    id="create-task-priority"
+                    name="priority"
+                    defaultValue="medium"
+                    className="mt-1 block w-full rounded-lg border border-gray-300 px-3 py-2 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+                  >
+                    <option value="low">低</option>
+                    <option value="medium">中</option>
+                    <option value="high">高</option>
+                  </select>
+                  {state.fieldErrors?.priority?.[0] && (
+                    <p className="mt-1 text-sm text-red-600">
+                      {state.fieldErrors.priority[0]}
+                    </p>
+                  )}
+                </div>
+              </div>
+
+              {state.error && <Alert variant="error">{state.error}</Alert>}
+
+              <div className="flex justify-end gap-3 pt-2">
+                <button
+                  type="button"
+                  onClick={closeModal}
+                  className="rounded-lg px-4 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-100"
+                >
+                  キャンセル
+                </button>
+                <SubmitButton size="sm" pendingText="作成中...">
+                  作成
+                </SubmitButton>
+              </div>
+            </form>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/components/tasks/DeleteTaskDialog.tsx
+++ b/src/components/tasks/DeleteTaskDialog.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { useEffect } from "react";
+import { useFormState } from "react-dom";
+import { SubmitButton, Alert } from "@/components/ui";
+import {
+  deleteTask,
+  type DeleteTaskState,
+} from "@/app/(dashboard)/projects/[projectId]/actions";
+import type { Task } from "@/types";
+
+const initialState: DeleteTaskState = {};
+
+interface DeleteTaskDialogProps {
+  task: Task;
+  projectId: string;
+  onClose: () => void;
+}
+
+export default function DeleteTaskDialog({
+  task,
+  projectId,
+  onClose,
+}: DeleteTaskDialogProps) {
+  const [state, formAction] = useFormState(deleteTask, initialState);
+
+  useEffect(() => {
+    if (state.success) {
+      onClose();
+    }
+  }, [state.success, onClose]);
+
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") {
+        onClose();
+      }
+    }
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [onClose]);
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      <div
+        className="absolute inset-0 bg-black/50 transition-opacity"
+        onClick={onClose}
+        aria-hidden="true"
+      />
+
+      <div className="relative w-full max-w-sm rounded-xl bg-white p-6 shadow-xl">
+        <h2 className="text-lg font-semibold">タスクを削除</h2>
+        <p className="mt-2 text-sm text-gray-600">
+          タスク「{task.title}」を削除しますか？この操作は取り消せません。
+        </p>
+
+        {state.error && (
+          <div className="mt-3">
+            <Alert variant="error">{state.error}</Alert>
+          </div>
+        )}
+
+        <form action={formAction}>
+          <input type="hidden" name="taskId" value={task.id} />
+          <input type="hidden" name="projectId" value={projectId} />
+          <div className="mt-4 flex justify-end gap-3">
+            <button
+              type="button"
+              onClick={onClose}
+              className="rounded-lg px-4 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-100"
+            >
+              キャンセル
+            </button>
+            <SubmitButton size="sm" variant="danger" pendingText="削除中...">
+              削除
+            </SubmitButton>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/src/components/tasks/EditTaskModal.tsx
+++ b/src/components/tasks/EditTaskModal.tsx
@@ -1,0 +1,168 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { useFormState } from "react-dom";
+import { XMarkIcon } from "@/components/icons";
+import { FormInput, SubmitButton, Alert } from "@/components/ui";
+import {
+  updateTask,
+  type UpdateTaskState,
+} from "@/app/(dashboard)/projects/[projectId]/actions";
+import type { Task } from "@/types";
+
+const initialState: UpdateTaskState = {};
+
+interface EditTaskModalProps {
+  task: Task;
+  projectId: string;
+  onClose: () => void;
+}
+
+export default function EditTaskModal({
+  task,
+  projectId,
+  onClose,
+}: EditTaskModalProps) {
+  const [state, formAction] = useFormState(updateTask, initialState);
+  const formRef = useRef<HTMLFormElement>(null);
+
+  useEffect(() => {
+    if (state.success) {
+      onClose();
+    }
+  }, [state.success, onClose]);
+
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") {
+        onClose();
+      }
+    }
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [onClose]);
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      <div
+        className="absolute inset-0 bg-black/50 transition-opacity"
+        onClick={onClose}
+        aria-hidden="true"
+      />
+
+      <div className="relative w-full max-w-md rounded-xl bg-white p-6 shadow-xl">
+        <div className="mb-4 flex items-center justify-between">
+          <h2 className="text-lg font-semibold">タスクを編集</h2>
+          <button
+            onClick={onClose}
+            className="rounded-lg p-1 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600"
+          >
+            <XMarkIcon className="h-5 w-5" />
+          </button>
+        </div>
+
+        <form ref={formRef} action={formAction} className="space-y-4">
+          <input type="hidden" name="taskId" value={task.id} />
+          <input type="hidden" name="projectId" value={projectId} />
+
+          <FormInput
+            label="タイトル"
+            name="title"
+            required
+            defaultValue={task.title}
+            placeholder="例: デザインレビュー"
+            error={state.fieldErrors?.title?.[0]}
+          />
+
+          <div>
+            <label
+              htmlFor="edit-task-description"
+              className="block text-sm font-medium text-gray-700"
+            >
+              説明（任意）
+            </label>
+            <textarea
+              id="edit-task-description"
+              name="description"
+              rows={3}
+              defaultValue={task.description ?? ""}
+              placeholder="タスクの説明を入力..."
+              className="mt-1 block w-full rounded-lg border border-gray-300 px-3 py-2 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+            />
+            {state.fieldErrors?.description?.[0] && (
+              <p className="mt-1 text-sm text-red-600">
+                {state.fieldErrors.description[0]}
+              </p>
+            )}
+          </div>
+
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <label
+                htmlFor="edit-task-status"
+                className="block text-sm font-medium text-gray-700"
+              >
+                ステータス
+              </label>
+              <select
+                id="edit-task-status"
+                name="status"
+                defaultValue={task.status}
+                className="mt-1 block w-full rounded-lg border border-gray-300 px-3 py-2 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+              >
+                <option value="todo">未着手</option>
+                <option value="in_progress">進行中</option>
+                <option value="done">完了</option>
+              </select>
+              {state.fieldErrors?.status?.[0] && (
+                <p className="mt-1 text-sm text-red-600">
+                  {state.fieldErrors.status[0]}
+                </p>
+              )}
+            </div>
+
+            <div>
+              <label
+                htmlFor="edit-task-priority"
+                className="block text-sm font-medium text-gray-700"
+              >
+                優先度
+              </label>
+              <select
+                id="edit-task-priority"
+                name="priority"
+                defaultValue={task.priority}
+                className="mt-1 block w-full rounded-lg border border-gray-300 px-3 py-2 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+              >
+                <option value="low">低</option>
+                <option value="medium">中</option>
+                <option value="high">高</option>
+              </select>
+              {state.fieldErrors?.priority?.[0] && (
+                <p className="mt-1 text-sm text-red-600">
+                  {state.fieldErrors.priority[0]}
+                </p>
+              )}
+            </div>
+          </div>
+
+          {state.error && <Alert variant="error">{state.error}</Alert>}
+
+          <div className="flex justify-end gap-3 pt-2">
+            <button
+              type="button"
+              onClick={onClose}
+              className="rounded-lg px-4 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-100"
+            >
+              キャンセル
+            </button>
+            <SubmitButton size="sm" pendingText="更新中...">
+              更新
+            </SubmitButton>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/src/components/tasks/TaskCard.tsx
+++ b/src/components/tasks/TaskCard.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { useState } from "react";
+import { PencilIcon, TrashIcon } from "@/components/icons";
+import EditTaskModal from "@/components/tasks/EditTaskModal";
+import DeleteTaskDialog from "@/components/tasks/DeleteTaskDialog";
+import type { Task, TaskStatus, TaskPriority } from "@/types";
+
+const statusLabels: Record<TaskStatus, string> = {
+  todo: "未着手",
+  in_progress: "進行中",
+  done: "完了",
+};
+
+const statusColors: Record<TaskStatus, string> = {
+  todo: "bg-gray-100 text-gray-700",
+  in_progress: "bg-blue-100 text-blue-700",
+  done: "bg-green-100 text-green-700",
+};
+
+const priorityLabels: Record<TaskPriority, string> = {
+  low: "低",
+  medium: "中",
+  high: "高",
+};
+
+const priorityColors: Record<TaskPriority, string> = {
+  low: "border-green-500 text-green-600",
+  medium: "border-yellow-500 text-yellow-600",
+  high: "border-red-500 text-red-600",
+};
+
+interface TaskCardProps {
+  task: Task;
+  projectId: string;
+}
+
+export default function TaskCard({ task, projectId }: TaskCardProps) {
+  const [showEdit, setShowEdit] = useState(false);
+  const [showDelete, setShowDelete] = useState(false);
+
+  return (
+    <>
+      <div className="flex items-center gap-4 rounded-lg bg-white p-4 shadow-sm">
+        <div className="min-w-0 flex-1">
+          <p className="font-medium text-gray-900">{task.title}</p>
+          {task.description && (
+            <p className="mt-1 truncate text-sm text-gray-500">
+              {task.description}
+            </p>
+          )}
+        </div>
+
+        <span
+          className={`whitespace-nowrap rounded-full px-3 py-1 text-sm font-medium ${statusColors[task.status]}`}
+        >
+          {statusLabels[task.status]}
+        </span>
+
+        <span
+          className={`whitespace-nowrap rounded-full border px-3 py-1 text-sm font-medium ${priorityColors[task.priority]}`}
+        >
+          {priorityLabels[task.priority]}
+        </span>
+
+        <div className="flex items-center gap-1">
+          <button
+            onClick={() => setShowEdit(true)}
+            className="rounded-lg p-1.5 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600"
+            title="編集"
+          >
+            <PencilIcon className="h-4 w-4" />
+          </button>
+          <button
+            onClick={() => setShowDelete(true)}
+            className="rounded-lg p-1.5 text-gray-400 transition-colors hover:bg-gray-100 hover:text-red-600"
+            title="削除"
+          >
+            <TrashIcon className="h-4 w-4" />
+          </button>
+        </div>
+      </div>
+
+      {showEdit && (
+        <EditTaskModal
+          task={task}
+          projectId={projectId}
+          onClose={() => setShowEdit(false)}
+        />
+      )}
+
+      {showDelete && (
+        <DeleteTaskDialog
+          task={task}
+          projectId={projectId}
+          onClose={() => setShowDelete(false)}
+        />
+      )}
+    </>
+  );
+}

--- a/src/components/tasks/TaskList.tsx
+++ b/src/components/tasks/TaskList.tsx
@@ -1,0 +1,28 @@
+import TaskCard from "@/components/tasks/TaskCard";
+import type { Task } from "@/types";
+
+interface TaskListProps {
+  tasks: Task[];
+  projectId: string;
+}
+
+export default function TaskList({ tasks, projectId }: TaskListProps) {
+  if (tasks.length === 0) {
+    return (
+      <div className="rounded-lg border-2 border-dashed border-gray-200 p-12 text-center">
+        <p className="text-gray-500">まだタスクがありません</p>
+        <p className="mt-1 text-sm text-gray-400">
+          「新規タスク」ボタンからタスクを作成してください
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      {tasks.map((task) => (
+        <TaskCard key={task.id} task={task} projectId={projectId} />
+      ))}
+    </div>
+  );
+}

--- a/src/components/tasks/TaskPrioritySelect.tsx
+++ b/src/components/tasks/TaskPrioritySelect.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { useRef } from "react";
+import { useFormState } from "react-dom";
+import {
+  updateTask,
+  type UpdateTaskState,
+} from "@/app/(dashboard)/projects/[projectId]/actions";
+import type { Task, TaskPriority } from "@/types";
+
+const initialState: UpdateTaskState = {};
+
+const priorityColors: Record<TaskPriority, string> = {
+  low: "border-green-500 text-green-600",
+  medium: "border-yellow-500 text-yellow-600",
+  high: "border-red-500 text-red-600",
+};
+
+interface TaskPrioritySelectProps {
+  task: Task;
+  projectId: string;
+}
+
+export default function TaskPrioritySelect({
+  task,
+  projectId,
+}: TaskPrioritySelectProps) {
+  const formRef = useRef<HTMLFormElement>(null);
+  const [, formAction] = useFormState(updateTask, initialState);
+
+  function handleChange() {
+    formRef.current?.requestSubmit();
+  }
+
+  return (
+    <form ref={formRef} action={formAction}>
+      <input type="hidden" name="taskId" value={task.id} />
+      <input type="hidden" name="projectId" value={projectId} />
+      <input type="hidden" name="title" value={task.title} />
+      <input type="hidden" name="description" value={task.description ?? ""} />
+      <input type="hidden" name="status" value={task.status} />
+      <select
+        name="priority"
+        defaultValue={task.priority}
+        onChange={handleChange}
+        className={`rounded-full border px-3 py-1 text-sm font-medium ${priorityColors[task.priority]} cursor-pointer bg-white focus:outline-none focus:ring-2 focus:ring-indigo-500`}
+      >
+        <option value="low">低</option>
+        <option value="medium">中</option>
+        <option value="high">高</option>
+      </select>
+    </form>
+  );
+}

--- a/src/components/tasks/TaskStatusSelect.tsx
+++ b/src/components/tasks/TaskStatusSelect.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { useRef } from "react";
+import { useFormState } from "react-dom";
+import {
+  updateTask,
+  type UpdateTaskState,
+} from "@/app/(dashboard)/projects/[projectId]/actions";
+import type { Task, TaskStatus } from "@/types";
+
+const initialState: UpdateTaskState = {};
+
+const statusColors: Record<TaskStatus, string> = {
+  todo: "bg-gray-100 text-gray-700",
+  in_progress: "bg-blue-100 text-blue-700",
+  done: "bg-green-100 text-green-700",
+};
+
+interface TaskStatusSelectProps {
+  task: Task;
+  projectId: string;
+}
+
+export default function TaskStatusSelect({
+  task,
+  projectId,
+}: TaskStatusSelectProps) {
+  const formRef = useRef<HTMLFormElement>(null);
+  const [, formAction] = useFormState(updateTask, initialState);
+
+  function handleChange() {
+    formRef.current?.requestSubmit();
+  }
+
+  return (
+    <form ref={formRef} action={formAction}>
+      <input type="hidden" name="taskId" value={task.id} />
+      <input type="hidden" name="projectId" value={projectId} />
+      <input type="hidden" name="title" value={task.title} />
+      <input type="hidden" name="description" value={task.description ?? ""} />
+      <input type="hidden" name="priority" value={task.priority} />
+      <select
+        name="status"
+        defaultValue={task.status}
+        onChange={handleChange}
+        className={`rounded-full px-3 py-1 text-sm font-medium ${statusColors[task.status]} cursor-pointer border-none focus:outline-none focus:ring-2 focus:ring-indigo-500`}
+      >
+        <option value="todo">未着手</option>
+        <option value="in_progress">進行中</option>
+        <option value="done">完了</option>
+      </select>
+    </form>
+  );
+}


### PR DESCRIPTION
## 概要

プロジェクト詳細ページにタスク CRUD 機能を実装。Phase 3（プロジェクト CRUD）のパターンを完全踏襲し、Server Actions + Zod バリデーション + モーダル UI で統一的な操作体験を提供する。

## 変更点

- Server Actions（createTask, updateTask, deleteTask）を追加
- TaskCard + TaskList コンポーネントを追加（ステータス・優先度バッジ付き）
- CreateTaskModal + EditTaskModal を追加（Phase 3 のモーダルパターン踏襲）
- DeleteTaskDialog を追加（確認ダイアログ付き削除）
- TaskStatusSelect + TaskPrioritySelect を追加（インライン変更）
- page.tsx を更新（モックタスク → Supabase 実データ取得 + 新コンポーネント配置）

## テストプラン

### エージェント確認済み
- [x] ESLint: エラーなし
- [x] TypeScript / ビルド: 成功
- [x] セキュリティチェック: 秘匿情報・個人情報の混入なし

### 手動確認（マージ前にユーザーが実施）
- [ ] プロジェクト詳細ページでタスク一覧が表示される（空状態 + データあり）
- [ ] 「新規タスク」ボタンからタスク作成ができる（バリデーション動作確認含む）
- [ ] タスクカードの編集ボタンから編集モーダルが開き、更新できる
- [ ] タスクカードの削除ボタンから確認ダイアログが表示され、削除できる
- [ ] ステータスバッジ・優先度バッジが正しい色で表示される
- [ ] 認証なしでアクセスするとログインページにリダイレクトされる

Closes #6