### PR TITLE
feat: タグ/ラベル機能の追加（Phase 5）

### DIFF
--- a/src/app/(dashboard)/projects/[projectId]/actions.ts
+++ b/src/app/(dashboard)/projects/[projectId]/actions.ts
@@ -3,6 +3,7 @@
 import { revalidatePath } from "next/cache";
 import { z } from "zod";
 import { createClient } from "@/lib/supabase/server";
+import type { Tag } from "@/types";
 
 // --- Zod Schemas ---
 
@@ -34,6 +35,14 @@ const updateTaskSchema = z.object({
   priority: z.enum(["low", "medium", "high"]),
 });
 
+const createTagSchema = z.object({
+  name: z
+    .string()
+    .min(1, "タグ名を入力してください")
+    .max(30, "タグ名は30文字以内で入力してください"),
+  color: z.string().regex(/^#[0-9a-fA-F]{6}$/, "無効なカラーコードです"),
+});
+
 // --- State Types ---
 
 export interface CreateTaskState {
@@ -45,6 +54,7 @@ export interface CreateTaskState {
     priority?: string[];
   };
   success?: boolean;
+  taskId?: string;
 }
 
 export interface UpdateTaskState {
@@ -59,6 +69,26 @@ export interface UpdateTaskState {
 }
 
 export interface DeleteTaskState {
+  error?: string;
+  success?: boolean;
+}
+
+export interface CreateTagState {
+  error?: string;
+  fieldErrors?: {
+    name?: string[];
+    color?: string[];
+  };
+  success?: boolean;
+  tag?: Tag;
+}
+
+export interface DeleteTagState {
+  error?: string;
+  success?: boolean;
+}
+
+export interface UpdateTaskTagsState {
   error?: string;
   success?: boolean;
 }
@@ -98,14 +128,18 @@ export async function createTask(
       };
     }
 
-    const { error } = await supabase.from("tasks").insert({
-      title: validatedFields.data.title,
-      description: validatedFields.data.description,
-      status: validatedFields.data.status,
-      priority: validatedFields.data.priority,
-      project_id: projectId,
-      created_by: user.id,
-    });
+    const { data, error } = await supabase
+      .from("tasks")
+      .insert({
+        title: validatedFields.data.title,
+        description: validatedFields.data.description,
+        status: validatedFields.data.status,
+        priority: validatedFields.data.priority,
+        project_id: projectId,
+        created_by: user.id,
+      })
+      .select("id")
+      .single();
 
     if (error) {
       return {
@@ -117,6 +151,7 @@ export async function createTask(
 
     return {
       success: true,
+      taskId: data.id,
     };
   } catch {
     return {
@@ -213,6 +248,183 @@ export async function deleteTask(
       return {
         error: "タスクの削除に失敗しました。もう一度お試しください。",
       };
+    }
+
+    revalidatePath(`/projects/${projectId}`);
+
+    return {
+      success: true,
+    };
+  } catch {
+    return {
+      error: "予期しないエラーが発生しました。もう一度お試しください。",
+    };
+  }
+}
+
+// --- Tag Server Actions ---
+
+export async function createTag(
+  _prevState: CreateTagState,
+  formData: FormData,
+): Promise<CreateTagState> {
+  const projectId = formData.get("projectId") as string;
+  const rawFormData = {
+    name: formData.get("name") as string,
+    color: formData.get("color") as string,
+  };
+
+  const validatedFields = createTagSchema.safeParse(rawFormData);
+
+  if (!validatedFields.success) {
+    return {
+      fieldErrors: validatedFields.error.flatten().fieldErrors,
+    };
+  }
+
+  try {
+    const supabase = await createClient();
+
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user) {
+      return {
+        error: "認証が必要です。ログインしてください。",
+      };
+    }
+
+    const { data, error } = await supabase
+      .from("tags")
+      .insert({
+        name: validatedFields.data.name,
+        color: validatedFields.data.color,
+        project_id: projectId,
+      })
+      .select()
+      .single();
+
+    if (error) {
+      if (error.code === "23505") {
+        return {
+          error: "同名のタグが既に存在します。",
+        };
+      }
+      return {
+        error: "タグの作成に失敗しました。もう一度お試しください。",
+      };
+    }
+
+    revalidatePath(`/projects/${projectId}`);
+
+    return {
+      success: true,
+      tag: data as Tag,
+    };
+  } catch {
+    return {
+      error: "予期しないエラーが発生しました。もう一度お試しください。",
+    };
+  }
+}
+
+export async function deleteTag(
+  _prevState: DeleteTagState,
+  formData: FormData,
+): Promise<DeleteTagState> {
+  const tagId = formData.get("tagId") as string;
+  const projectId = formData.get("projectId") as string;
+
+  try {
+    const supabase = await createClient();
+
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user) {
+      return {
+        error: "認証が必要です。ログインしてください。",
+      };
+    }
+
+    const { error } = await supabase.from("tags").delete().eq("id", tagId);
+
+    if (error) {
+      return {
+        error: "タグの削除に失敗しました。もう一度お試しください。",
+      };
+    }
+
+    revalidatePath(`/projects/${projectId}`);
+
+    return {
+      success: true,
+    };
+  } catch {
+    return {
+      error: "予期しないエラーが発生しました。もう一度お試しください。",
+    };
+  }
+}
+
+export async function updateTaskTags(
+  _prevState: UpdateTaskTagsState,
+  formData: FormData,
+): Promise<UpdateTaskTagsState> {
+  const taskId = formData.get("taskId") as string;
+  const projectId = formData.get("projectId") as string;
+  const tagIdsJson = formData.get("tagIds") as string;
+
+  let tagIds: string[];
+  try {
+    tagIds = JSON.parse(tagIdsJson);
+  } catch {
+    return {
+      error: "タグ情報が不正です。",
+    };
+  }
+
+  try {
+    const supabase = await createClient();
+
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user) {
+      return {
+        error: "認証が必要です。ログインしてください。",
+      };
+    }
+
+    // 既存の紐付けを削除
+    const { error: deleteError } = await supabase
+      .from("task_tags")
+      .delete()
+      .eq("task_id", taskId);
+
+    if (deleteError) {
+      return {
+        error: "タグの更新に失敗しました。もう一度お試しください。",
+      };
+    }
+
+    // 新しい紐付けを挿入
+    if (tagIds.length > 0) {
+      const { error: insertError } = await supabase.from("task_tags").insert(
+        tagIds.map((tagId) => ({
+          task_id: taskId,
+          tag_id: tagId,
+        })),
+      );
+
+      if (insertError) {
+        return {
+          error: "タグの更新に失敗しました。もう一度お試しください。",
+        };
+      }
     }
 
     revalidatePath(`/projects/${projectId}`);

--- a/src/app/(dashboard)/projects/[projectId]/page.tsx
+++ b/src/app/(dashboard)/projects/[projectId]/page.tsx
@@ -5,7 +5,7 @@ import { ListIcon, KanbanIcon } from "@/components/icons";
 import ProjectDetailActions from "@/components/projects/ProjectDetailActions";
 import CreateTaskModal from "@/components/tasks/CreateTaskModal";
 import TaskList from "@/components/tasks/TaskList";
-import type { Project, Task } from "@/types";
+import type { Project, Tag, TaskWithTags } from "@/types";
 
 export const dynamic = "force-dynamic";
 
@@ -38,13 +38,48 @@ export default async function ProjectDetailPage({ params }: Props) {
 
   const typedProject = project as Project;
 
+  // タグ一覧を取得
+  const { data: tags } = await supabase
+    .from("tags")
+    .select("*")
+    .eq("project_id", projectId)
+    .order("name");
+
+  const typedTags = (tags ?? []) as Tag[];
+
+  // タスク一覧を取得（タグ付き）
   const { data: tasks } = await supabase
     .from("tasks")
-    .select("*")
+    .select(
+      `
+      *,
+      task_tags(
+        tag_id,
+        tags(*)
+      )
+    `,
+    )
     .eq("project_id", projectId)
     .order("created_at", { ascending: false });
 
-  const typedTasks = (tasks ?? []) as Task[];
+  // タスクデータを TaskWithTags 型に変換
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const typedTasks: TaskWithTags[] = (tasks ?? []).map((task: any) => ({
+    id: task.id,
+    title: task.title,
+    description: task.description,
+    status: task.status,
+    priority: task.priority,
+    due_date: task.due_date,
+    position: task.position,
+    project_id: task.project_id,
+    created_by: task.created_by,
+    created_at: task.created_at,
+    updated_at: task.updated_at,
+    tags: (task.task_tags ?? [])
+      .map((tt: { tags: Tag }) => tt.tags)
+      .filter(Boolean),
+  }));
 
   return (
     <div>
@@ -57,7 +92,7 @@ export default async function ProjectDetailPage({ params }: Props) {
         </div>
         <div className="flex items-center gap-2">
           <ProjectDetailActions project={typedProject} />
-          <CreateTaskModal projectId={projectId} />
+          <CreateTaskModal projectId={projectId} availableTags={typedTags} />
           <button
             disabled
             className="flex items-center gap-2 rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white"
@@ -75,7 +110,11 @@ export default async function ProjectDetailPage({ params }: Props) {
         </div>
       </div>
 
-      <TaskList tasks={typedTasks} projectId={projectId} />
+      <TaskList
+        tasks={typedTasks}
+        projectId={projectId}
+        availableTags={typedTags}
+      />
     </div>
   );
 }

--- a/src/components/icons/index.tsx
+++ b/src/components/icons/index.tsx
@@ -197,6 +197,49 @@ export function TrashIcon({ className }: IconProps) {
   );
 }
 
+export function TagIcon({ className }: IconProps) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+      className={className}
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M9.568 3H5.25A2.25 2.25 0 0 0 3 5.25v4.318c0 .597.237 1.17.659 1.591l9.581 9.581c.699.699 1.78.872 2.607.33a18.095 18.095 0 0 0 5.223-5.223c.542-.827.369-1.908-.33-2.607L11.16 3.66A2.25 2.25 0 0 0 9.568 3Z"
+      />
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M6 6h.008v.008H6V6Z"
+      />
+    </svg>
+  );
+}
+
+export function CheckIcon({ className }: IconProps) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={2}
+      stroke="currentColor"
+      className={className}
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="m4.5 12.75 6 6 9-13.5"
+      />
+    </svg>
+  );
+}
+
 export function LogoutIcon({ className }: IconProps) {
   return (
     <svg

--- a/src/components/tags/TagBadge.tsx
+++ b/src/components/tags/TagBadge.tsx
@@ -1,0 +1,40 @@
+import { XMarkIcon } from "@/components/icons";
+import type { Tag } from "@/types";
+
+interface TagBadgeProps {
+  tag: Tag;
+  size?: "sm" | "md";
+  onRemove?: () => void;
+}
+
+export default function TagBadge({
+  tag,
+  size = "sm",
+  onRemove,
+}: TagBadgeProps) {
+  const sizeClasses = {
+    sm: "text-xs px-2 py-0.5",
+    md: "text-sm px-2.5 py-1",
+  };
+
+  return (
+    <span
+      className={`inline-flex items-center gap-1 rounded-full font-medium ${sizeClasses[size]}`}
+      style={{
+        backgroundColor: `${tag.color}1a`,
+        color: tag.color,
+      }}
+    >
+      {tag.name}
+      {onRemove && (
+        <button
+          type="button"
+          onClick={onRemove}
+          className="rounded-full p-0.5 transition-colors hover:bg-black/10"
+        >
+          <XMarkIcon className="h-3 w-3" />
+        </button>
+      )}
+    </span>
+  );
+}

--- a/src/components/tags/TagColorPicker.tsx
+++ b/src/components/tags/TagColorPicker.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { CheckIcon } from "@/components/icons";
+
+export const PRESET_COLORS = [
+  { name: "gray", value: "#6b7280" },
+  { name: "red", value: "#ef4444" },
+  { name: "orange", value: "#f97316" },
+  { name: "amber", value: "#f59e0b" },
+  { name: "green", value: "#22c55e" },
+  { name: "teal", value: "#14b8a6" },
+  { name: "blue", value: "#3b82f6" },
+  { name: "indigo", value: "#6366f1" },
+  { name: "purple", value: "#a855f7" },
+  { name: "pink", value: "#ec4899" },
+] as const;
+
+export const DEFAULT_TAG_COLOR = "#6366f1";
+
+interface TagColorPickerProps {
+  selectedColor: string;
+  onColorSelect: (color: string) => void;
+}
+
+export default function TagColorPicker({
+  selectedColor,
+  onColorSelect,
+}: TagColorPickerProps) {
+  return (
+    <div className="flex flex-wrap gap-2">
+      {PRESET_COLORS.map((color) => (
+        <button
+          key={color.name}
+          type="button"
+          onClick={() => onColorSelect(color.value)}
+          className="flex h-6 w-6 items-center justify-center rounded-full transition-transform hover:scale-110"
+          style={{ backgroundColor: color.value }}
+          title={color.name}
+        >
+          {selectedColor === color.value && (
+            <CheckIcon className="h-3.5 w-3.5 text-white" />
+          )}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/src/components/tags/TagSelector.tsx
+++ b/src/components/tags/TagSelector.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef, useEffect, useTransition } from "react";
+import { useState, useRef, useEffect, useTransition, useCallback } from "react";
 import { PlusIcon, TagIcon } from "@/components/icons";
 import TagBadge from "@/components/tags/TagBadge";
 import TagColorPicker, {
@@ -30,8 +30,10 @@ export default function TagSelector({
   const [newTagColor, setNewTagColor] = useState(DEFAULT_TAG_COLOR);
   const [error, setError] = useState<string | null>(null);
   const [isPending, startTransition] = useTransition();
+  const [highlightedIndex, setHighlightedIndex] = useState(-1);
   const dropdownRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
 
   // ドロップダウン外クリックで閉じる
   useEffect(() => {
@@ -43,6 +45,7 @@ export default function TagSelector({
         setIsOpen(false);
         setIsCreating(false);
         setSearch("");
+        setHighlightedIndex(-1);
       }
     }
 
@@ -64,6 +67,15 @@ export default function TagSelector({
       (tag) => tag.name.toLowerCase() === search.trim().toLowerCase(),
     );
 
+  // キーボードナビ用の選択可能アイテム数（タグ + 作成オプション）
+  const totalItems =
+    filteredTags.length + (showCreateOption && !isCreating ? 1 : 0);
+
+  // 検索テキスト変更時にハイライトをリセット
+  useEffect(() => {
+    setHighlightedIndex(-1);
+  }, [search]);
+
   function handleToggleTag(tagId: string) {
     if (selectedTagIds.includes(tagId)) {
       onTagsChange(selectedTagIds.filter((id) => id !== tagId));
@@ -80,9 +92,10 @@ export default function TagSelector({
     setIsCreating(true);
     setNewTagColor(DEFAULT_TAG_COLOR);
     setError(null);
+    setHighlightedIndex(-1);
   }
 
-  function handleCreateTag() {
+  const handleCreateTag = useCallback(() => {
     const tagName = search.trim();
     if (!tagName) return;
 
@@ -99,13 +112,68 @@ export default function TagSelector({
         setSearch("");
         setIsCreating(false);
         setError(null);
+        setHighlightedIndex(-1);
       } else if (result.error) {
         setError(result.error);
       } else if (result.fieldErrors?.name) {
         setError(result.fieldErrors.name[0]);
       }
     });
+  }, [
+    search,
+    newTagColor,
+    projectId,
+    selectedTagIds,
+    onTagCreated,
+    onTagsChange,
+    startTransition,
+  ]);
+
+  // キーボードナビゲーション
+  function handleKeyDown(e: React.KeyboardEvent) {
+    if (!isOpen) return;
+
+    // 作成フォーム表示中はナビ無効（フォーム内操作を優先）
+    if (isCreating) return;
+
+    switch (e.key) {
+      case "ArrowDown":
+        e.preventDefault();
+        setHighlightedIndex((prev) => (prev < totalItems - 1 ? prev + 1 : 0));
+        break;
+      case "ArrowUp":
+        e.preventDefault();
+        setHighlightedIndex((prev) => (prev > 0 ? prev - 1 : totalItems - 1));
+        break;
+      case "Enter":
+        e.preventDefault();
+        if (highlightedIndex >= 0 && highlightedIndex < filteredTags.length) {
+          handleToggleTag(filteredTags[highlightedIndex].id);
+        } else if (
+          highlightedIndex === filteredTags.length &&
+          showCreateOption
+        ) {
+          handleStartCreate();
+        }
+        break;
+      case "Escape":
+        e.preventDefault();
+        setIsOpen(false);
+        setSearch("");
+        setHighlightedIndex(-1);
+        break;
+    }
   }
+
+  // ハイライト項目を自動スクロール
+  useEffect(() => {
+    if (highlightedIndex < 0 || !listRef.current) return;
+    const items = listRef.current.querySelectorAll("[data-tag-item]");
+    const item = items[highlightedIndex];
+    if (item) {
+      item.scrollIntoView({ block: "nearest" });
+    }
+  }, [highlightedIndex]);
 
   const selectedTags = availableTags.filter((tag) =>
     selectedTagIds.includes(tag.id),
@@ -144,7 +212,11 @@ export default function TagSelector({
 
       {/* ドロップダウン */}
       {isOpen && (
-        <div className="absolute z-10 mt-1 w-full rounded-lg border border-gray-200 bg-white shadow-lg">
+        <div
+          className="absolute z-10 mt-1 w-full rounded-lg border border-gray-200 bg-white shadow-lg"
+          role="listbox"
+          aria-label="タグを選択"
+        >
           {/* 検索入力 */}
           <div className="border-b border-gray-100 p-2">
             <input
@@ -156,24 +228,45 @@ export default function TagSelector({
                 setIsCreating(false);
                 setError(null);
               }}
+              onKeyDown={handleKeyDown}
               placeholder="タグを検索または作成..."
               className="w-full rounded-md border border-gray-200 px-2.5 py-1.5 text-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+              role="combobox"
+              aria-controls="tag-listbox"
+              aria-expanded={isOpen}
+              aria-activedescendant={
+                highlightedIndex >= 0 && highlightedIndex < filteredTags.length
+                  ? `tag-option-${filteredTags[highlightedIndex].id}`
+                  : undefined
+              }
             />
           </div>
 
           {/* タグリスト */}
-          <div className="max-h-48 overflow-y-auto p-1">
-            {filteredTags.map((tag) => {
+          <div
+            ref={listRef}
+            id="tag-listbox"
+            className="max-h-48 overflow-y-auto p-1"
+          >
+            {filteredTags.map((tag, index) => {
               const isSelected = selectedTagIds.includes(tag.id);
+              const isHighlighted = index === highlightedIndex;
               return (
                 <button
                   key={tag.id}
+                  id={`tag-option-${tag.id}`}
+                  data-tag-item
                   type="button"
+                  role="option"
+                  aria-selected={isSelected}
                   onClick={() => handleToggleTag(tag.id)}
+                  onMouseEnter={() => setHighlightedIndex(index)}
                   className={`flex w-full items-center gap-2 rounded-md px-2.5 py-1.5 text-left text-sm transition-colors ${
-                    isSelected
+                    isHighlighted
                       ? "bg-indigo-50 text-indigo-700"
-                      : "text-gray-700 hover:bg-gray-50"
+                      : isSelected
+                        ? "bg-indigo-50/50 text-indigo-700"
+                        : "text-gray-700 hover:bg-gray-50"
                   }`}
                 >
                   <span
@@ -197,9 +290,15 @@ export default function TagSelector({
             {/* 新規作成オプション */}
             {showCreateOption && !isCreating && (
               <button
+                data-tag-item
                 type="button"
                 onClick={handleStartCreate}
-                className="flex w-full items-center gap-2 rounded-md px-2.5 py-1.5 text-left text-sm text-indigo-600 transition-colors hover:bg-indigo-50"
+                onMouseEnter={() => setHighlightedIndex(filteredTags.length)}
+                className={`flex w-full items-center gap-2 rounded-md px-2.5 py-1.5 text-left text-sm transition-colors ${
+                  highlightedIndex === filteredTags.length
+                    ? "bg-indigo-50 text-indigo-700"
+                    : "text-indigo-600 hover:bg-indigo-50"
+                }`}
               >
                 <PlusIcon className="h-4 w-4" />
                 <span>&ldquo;{search.trim()}&rdquo; を作成</span>

--- a/src/components/tags/TagSelector.tsx
+++ b/src/components/tags/TagSelector.tsx
@@ -1,0 +1,247 @@
+"use client";
+
+import { useState, useRef, useEffect, useTransition } from "react";
+import { PlusIcon, TagIcon } from "@/components/icons";
+import TagBadge from "@/components/tags/TagBadge";
+import TagColorPicker, {
+  DEFAULT_TAG_COLOR,
+} from "@/components/tags/TagColorPicker";
+import { createTag } from "@/app/(dashboard)/projects/[projectId]/actions";
+import type { Tag } from "@/types";
+
+interface TagSelectorProps {
+  projectId: string;
+  availableTags: Tag[];
+  selectedTagIds: string[];
+  onTagsChange: (tagIds: string[]) => void;
+  onTagCreated: (tag: Tag) => void;
+}
+
+export default function TagSelector({
+  projectId,
+  availableTags,
+  selectedTagIds,
+  onTagsChange,
+  onTagCreated,
+}: TagSelectorProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [search, setSearch] = useState("");
+  const [isCreating, setIsCreating] = useState(false);
+  const [newTagColor, setNewTagColor] = useState(DEFAULT_TAG_COLOR);
+  const [error, setError] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+  const dropdownRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // ドロップダウン外クリックで閉じる
+  useEffect(() => {
+    function handleClickOutside(e: MouseEvent) {
+      if (
+        dropdownRef.current &&
+        !dropdownRef.current.contains(e.target as Node)
+      ) {
+        setIsOpen(false);
+        setIsCreating(false);
+        setSearch("");
+      }
+    }
+
+    if (isOpen) {
+      document.addEventListener("mousedown", handleClickOutside);
+      return () =>
+        document.removeEventListener("mousedown", handleClickOutside);
+    }
+  }, [isOpen]);
+
+  // 検索フィルタリング
+  const filteredTags = availableTags.filter((tag) =>
+    tag.name.toLowerCase().includes(search.toLowerCase()),
+  );
+
+  const showCreateOption =
+    search.trim() !== "" &&
+    !availableTags.some(
+      (tag) => tag.name.toLowerCase() === search.trim().toLowerCase(),
+    );
+
+  function handleToggleTag(tagId: string) {
+    if (selectedTagIds.includes(tagId)) {
+      onTagsChange(selectedTagIds.filter((id) => id !== tagId));
+    } else {
+      onTagsChange([...selectedTagIds, tagId]);
+    }
+  }
+
+  function handleRemoveTag(tagId: string) {
+    onTagsChange(selectedTagIds.filter((id) => id !== tagId));
+  }
+
+  function handleStartCreate() {
+    setIsCreating(true);
+    setNewTagColor(DEFAULT_TAG_COLOR);
+    setError(null);
+  }
+
+  function handleCreateTag() {
+    const tagName = search.trim();
+    if (!tagName) return;
+
+    const formData = new FormData();
+    formData.set("name", tagName);
+    formData.set("color", newTagColor);
+    formData.set("projectId", projectId);
+
+    startTransition(async () => {
+      const result = await createTag({}, formData);
+      if (result.success && result.tag) {
+        onTagCreated(result.tag);
+        onTagsChange([...selectedTagIds, result.tag.id]);
+        setSearch("");
+        setIsCreating(false);
+        setError(null);
+      } else if (result.error) {
+        setError(result.error);
+      } else if (result.fieldErrors?.name) {
+        setError(result.fieldErrors.name[0]);
+      }
+    });
+  }
+
+  const selectedTags = availableTags.filter((tag) =>
+    selectedTagIds.includes(tag.id),
+  );
+
+  return (
+    <div ref={dropdownRef} className="relative">
+      <label className="block text-sm font-medium text-gray-700">タグ</label>
+
+      {/* 選択済みタグ + 開閉ボタン */}
+      <div
+        className="mt-1 flex min-h-[38px] cursor-pointer flex-wrap items-center gap-1 rounded-lg border border-gray-300 px-3 py-1.5 shadow-sm transition-colors hover:border-gray-400"
+        onClick={() => {
+          setIsOpen(!isOpen);
+          if (!isOpen) {
+            setTimeout(() => inputRef.current?.focus(), 0);
+          }
+        }}
+      >
+        {selectedTags.length > 0 ? (
+          selectedTags.map((tag) => (
+            <TagBadge
+              key={tag.id}
+              tag={tag}
+              size="sm"
+              onRemove={() => handleRemoveTag(tag.id)}
+            />
+          ))
+        ) : (
+          <span className="flex items-center gap-1 text-sm text-gray-400">
+            <TagIcon className="h-4 w-4" />
+            タグを選択...
+          </span>
+        )}
+      </div>
+
+      {/* ドロップダウン */}
+      {isOpen && (
+        <div className="absolute z-10 mt-1 w-full rounded-lg border border-gray-200 bg-white shadow-lg">
+          {/* 検索入力 */}
+          <div className="border-b border-gray-100 p-2">
+            <input
+              ref={inputRef}
+              type="text"
+              value={search}
+              onChange={(e) => {
+                setSearch(e.target.value);
+                setIsCreating(false);
+                setError(null);
+              }}
+              placeholder="タグを検索または作成..."
+              className="w-full rounded-md border border-gray-200 px-2.5 py-1.5 text-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+            />
+          </div>
+
+          {/* タグリスト */}
+          <div className="max-h-48 overflow-y-auto p-1">
+            {filteredTags.map((tag) => {
+              const isSelected = selectedTagIds.includes(tag.id);
+              return (
+                <button
+                  key={tag.id}
+                  type="button"
+                  onClick={() => handleToggleTag(tag.id)}
+                  className={`flex w-full items-center gap-2 rounded-md px-2.5 py-1.5 text-left text-sm transition-colors ${
+                    isSelected
+                      ? "bg-indigo-50 text-indigo-700"
+                      : "text-gray-700 hover:bg-gray-50"
+                  }`}
+                >
+                  <span
+                    className="h-3 w-3 shrink-0 rounded-full"
+                    style={{ backgroundColor: tag.color }}
+                  />
+                  <span className="flex-1 truncate">{tag.name}</span>
+                  {isSelected && (
+                    <span className="text-xs text-indigo-500">✓</span>
+                  )}
+                </button>
+              );
+            })}
+
+            {filteredTags.length === 0 && !showCreateOption && (
+              <p className="px-2.5 py-2 text-center text-sm text-gray-400">
+                タグが見つかりません
+              </p>
+            )}
+
+            {/* 新規作成オプション */}
+            {showCreateOption && !isCreating && (
+              <button
+                type="button"
+                onClick={handleStartCreate}
+                className="flex w-full items-center gap-2 rounded-md px-2.5 py-1.5 text-left text-sm text-indigo-600 transition-colors hover:bg-indigo-50"
+              >
+                <PlusIcon className="h-4 w-4" />
+                <span>&ldquo;{search.trim()}&rdquo; を作成</span>
+              </button>
+            )}
+          </div>
+
+          {/* インライン作成フォーム */}
+          {isCreating && (
+            <div className="border-t border-gray-100 p-3">
+              <p className="mb-2 text-xs font-medium text-gray-500">
+                &ldquo;{search.trim()}&rdquo; のカラーを選択
+              </p>
+              <TagColorPicker
+                selectedColor={newTagColor}
+                onColorSelect={setNewTagColor}
+              />
+              {error && <p className="mt-2 text-xs text-red-600">{error}</p>}
+              <div className="mt-3 flex justify-end gap-2">
+                <button
+                  type="button"
+                  onClick={() => {
+                    setIsCreating(false);
+                    setError(null);
+                  }}
+                  className="rounded-md px-2.5 py-1 text-xs text-gray-500 transition-colors hover:bg-gray-100"
+                >
+                  キャンセル
+                </button>
+                <button
+                  type="button"
+                  onClick={handleCreateTag}
+                  disabled={isPending}
+                  className="rounded-md bg-indigo-600 px-2.5 py-1 text-xs font-medium text-white transition-colors hover:bg-indigo-700 disabled:opacity-50"
+                >
+                  {isPending ? "作成中..." : "追加"}
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/tasks/CreateTaskModal.tsx
+++ b/src/components/tasks/CreateTaskModal.tsx
@@ -1,36 +1,68 @@
 "use client";
 
-import { useEffect, useRef, useState, useCallback } from "react";
+import { useEffect, useRef, useState, useCallback, useTransition } from "react";
 import { useFormState } from "react-dom";
 import { PlusIcon, XMarkIcon } from "@/components/icons";
 import { FormInput, SubmitButton, Alert } from "@/components/ui";
+import TagSelector from "@/components/tags/TagSelector";
 import {
   createTask,
+  updateTaskTags,
   type CreateTaskState,
 } from "@/app/(dashboard)/projects/[projectId]/actions";
+import type { Tag } from "@/types";
 
 const initialState: CreateTaskState = {};
 
 interface CreateTaskModalProps {
   projectId: string;
+  availableTags: Tag[];
 }
 
-export default function CreateTaskModal({ projectId }: CreateTaskModalProps) {
+export default function CreateTaskModal({
+  projectId,
+  availableTags: initialTags,
+}: CreateTaskModalProps) {
   const [isOpen, setIsOpen] = useState(false);
   const [state, formAction] = useFormState(createTask, initialState);
   const formRef = useRef<HTMLFormElement>(null);
+  const [selectedTagIds, setSelectedTagIds] = useState<string[]>([]);
+  const [localTags, setLocalTags] = useState<Tag[]>(initialTags);
+  const [, startTransition] = useTransition();
+
+  // 親から渡されるタグリストが更新されたら同期
+  useEffect(() => {
+    setLocalTags(initialTags);
+  }, [initialTags]);
 
   const closeModal = useCallback(() => {
     setIsOpen(false);
+    setSelectedTagIds([]);
   }, []);
 
-  // 成功時にモーダルを閉じてフォームをリセット
+  // 成功時にタグを紐付けてからモーダルを閉じる
   useEffect(() => {
-    if (state.success) {
+    if (state.success && state.taskId) {
+      if (selectedTagIds.length > 0) {
+        const formData = new FormData();
+        formData.set("taskId", state.taskId);
+        formData.set("projectId", projectId);
+        formData.set("tagIds", JSON.stringify(selectedTagIds));
+        startTransition(async () => {
+          await updateTaskTags({}, formData);
+        });
+      }
       closeModal();
       formRef.current?.reset();
     }
-  }, [state.success, closeModal]);
+  }, [
+    state.success,
+    state.taskId,
+    selectedTagIds,
+    projectId,
+    closeModal,
+    startTransition,
+  ]);
 
   // Escape キーでモーダルを閉じる
   useEffect(() => {
@@ -45,6 +77,10 @@ export default function CreateTaskModal({ projectId }: CreateTaskModalProps) {
       return () => document.removeEventListener("keydown", handleKeyDown);
     }
   }, [isOpen, closeModal]);
+
+  function handleTagCreated(tag: Tag) {
+    setLocalTags((prev) => [...prev, tag]);
+  }
 
   return (
     <>
@@ -160,6 +196,14 @@ export default function CreateTaskModal({ projectId }: CreateTaskModalProps) {
                   )}
                 </div>
               </div>
+
+              <TagSelector
+                projectId={projectId}
+                availableTags={localTags}
+                selectedTagIds={selectedTagIds}
+                onTagsChange={setSelectedTagIds}
+                onTagCreated={handleTagCreated}
+              />
 
               {state.error && <Alert variant="error">{state.error}</Alert>}
 

--- a/src/components/tasks/EditTaskModal.tsx
+++ b/src/components/tasks/EditTaskModal.tsx
@@ -1,36 +1,65 @@
 "use client";
 
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState, useTransition } from "react";
 import { useFormState } from "react-dom";
 import { XMarkIcon } from "@/components/icons";
 import { FormInput, SubmitButton, Alert } from "@/components/ui";
+import TagSelector from "@/components/tags/TagSelector";
 import {
   updateTask,
+  updateTaskTags,
   type UpdateTaskState,
 } from "@/app/(dashboard)/projects/[projectId]/actions";
-import type { Task } from "@/types";
+import type { Tag, TaskWithTags } from "@/types";
 
 const initialState: UpdateTaskState = {};
 
 interface EditTaskModalProps {
-  task: Task;
+  task: TaskWithTags;
   projectId: string;
+  availableTags: Tag[];
   onClose: () => void;
 }
 
 export default function EditTaskModal({
   task,
   projectId,
+  availableTags: initialTags,
   onClose,
 }: EditTaskModalProps) {
   const [state, formAction] = useFormState(updateTask, initialState);
   const formRef = useRef<HTMLFormElement>(null);
+  const [selectedTagIds, setSelectedTagIds] = useState<string[]>(
+    task.tags.map((t) => t.id),
+  );
+  const [localTags, setLocalTags] = useState<Tag[]>(initialTags);
+  const [, startTransition] = useTransition();
 
+  // 親から渡されるタグリストが更新されたら同期
+  useEffect(() => {
+    setLocalTags(initialTags);
+  }, [initialTags]);
+
+  // 成功時にタグを更新してからモーダルを閉じる
   useEffect(() => {
     if (state.success) {
+      const formData = new FormData();
+      formData.set("taskId", task.id);
+      formData.set("projectId", projectId);
+      formData.set("tagIds", JSON.stringify(selectedTagIds));
+      startTransition(async () => {
+        await updateTaskTags({}, formData);
+      });
       onClose();
     }
-  }, [state.success, onClose]);
+  }, [
+    state.success,
+    task.id,
+    selectedTagIds,
+    projectId,
+    onClose,
+    startTransition,
+  ]);
 
   useEffect(() => {
     function handleKeyDown(e: KeyboardEvent) {
@@ -42,6 +71,10 @@ export default function EditTaskModal({
     document.addEventListener("keydown", handleKeyDown);
     return () => document.removeEventListener("keydown", handleKeyDown);
   }, [onClose]);
+
+  function handleTagCreated(tag: Tag) {
+    setLocalTags((prev) => [...prev, tag]);
+  }
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center">
@@ -146,6 +179,14 @@ export default function EditTaskModal({
               )}
             </div>
           </div>
+
+          <TagSelector
+            projectId={projectId}
+            availableTags={localTags}
+            selectedTagIds={selectedTagIds}
+            onTagsChange={setSelectedTagIds}
+            onTagCreated={handleTagCreated}
+          />
 
           {state.error && <Alert variant="error">{state.error}</Alert>}
 

--- a/src/components/tasks/TaskCard.tsx
+++ b/src/components/tasks/TaskCard.tsx
@@ -4,7 +4,8 @@ import { useState } from "react";
 import { PencilIcon, TrashIcon } from "@/components/icons";
 import EditTaskModal from "@/components/tasks/EditTaskModal";
 import DeleteTaskDialog from "@/components/tasks/DeleteTaskDialog";
-import type { Task, TaskStatus, TaskPriority } from "@/types";
+import TagBadge from "@/components/tags/TagBadge";
+import type { TaskWithTags, TaskStatus, TaskPriority, Tag } from "@/types";
 
 const statusLabels: Record<TaskStatus, string> = {
   todo: "未着手",
@@ -31,11 +32,16 @@ const priorityColors: Record<TaskPriority, string> = {
 };
 
 interface TaskCardProps {
-  task: Task;
+  task: TaskWithTags;
   projectId: string;
+  availableTags: Tag[];
 }
 
-export default function TaskCard({ task, projectId }: TaskCardProps) {
+export default function TaskCard({
+  task,
+  projectId,
+  availableTags,
+}: TaskCardProps) {
   const [showEdit, setShowEdit] = useState(false);
   const [showDelete, setShowDelete] = useState(false);
 
@@ -48,6 +54,13 @@ export default function TaskCard({ task, projectId }: TaskCardProps) {
             <p className="mt-1 truncate text-sm text-gray-500">
               {task.description}
             </p>
+          )}
+          {task.tags.length > 0 && (
+            <div className="mt-2 flex flex-wrap gap-1">
+              {task.tags.map((tag) => (
+                <TagBadge key={tag.id} tag={tag} size="sm" />
+              ))}
+            </div>
           )}
         </div>
 
@@ -85,6 +98,7 @@ export default function TaskCard({ task, projectId }: TaskCardProps) {
         <EditTaskModal
           task={task}
           projectId={projectId}
+          availableTags={availableTags}
           onClose={() => setShowEdit(false)}
         />
       )}

--- a/src/components/tasks/TaskList.tsx
+++ b/src/components/tasks/TaskList.tsx
@@ -1,12 +1,17 @@
 import TaskCard from "@/components/tasks/TaskCard";
-import type { Task } from "@/types";
+import type { TaskWithTags, Tag } from "@/types";
 
 interface TaskListProps {
-  tasks: Task[];
+  tasks: TaskWithTags[];
   projectId: string;
+  availableTags: Tag[];
 }
 
-export default function TaskList({ tasks, projectId }: TaskListProps) {
+export default function TaskList({
+  tasks,
+  projectId,
+  availableTags,
+}: TaskListProps) {
   if (tasks.length === 0) {
     return (
       <div className="rounded-lg border-2 border-dashed border-gray-200 p-12 text-center">
@@ -21,7 +26,12 @@ export default function TaskList({ tasks, projectId }: TaskListProps) {
   return (
     <div className="space-y-2">
       {tasks.map((task) => (
-        <TaskCard key={task.id} task={task} projectId={projectId} />
+        <TaskCard
+          key={task.id}
+          task={task}
+          projectId={projectId}
+          availableTags={availableTags}
+        />
       ))}
     </div>
   );


### PR DESCRIPTION
## 概要

タスクにタグ（ラベル）を付けられる機能を追加。Notionライクに、タスク作成・編集モーダル内でタグの検索・選択・インライン作成ができるUIを実装。

## 変更点

- **TagSelector**: タスクモーダル内でタグを検索・選択・新規作成できるドロップダウンUI
- **TagBadge**: タグの色付きバッジ表示コンポーネント
- **TagColorPicker**: 10色のプリセットカラー選択UI
- Server Actions: `createTag`, `deleteTag`, `updateTaskTags` を追加
- `createTask` の戻り値に `taskId` を追加（タグ紐付けのため）
- `CreateTaskModal` / `EditTaskModal` に TagSelector を組み込み
- `TaskCard` にタグバッジ表示を追加
- `page.tsx` でタグ付きタスクをSupabase JOINクエリで取得（N+1回避）

## 前提条件

Supabaseダッシュボードで `tags` テーブルと `task_tags` テーブルを作成する必要があります。
SQLは設計書 `.claude/docs/design-phase5-tags.md` の「前提条件」セクションを参照してください。

## テストプラン

### エージェント確認済み
- [x] ESLint: エラーなし
- [x] TypeScript / ビルド: 成功
- [x] セキュリティチェック: 秘匿情報・個人情報の混入なし

### 手動確認（マージ前にユーザーが実施）
- [ ] Supabaseで `tags` / `task_tags` テーブルのSQL実行
- [ ] タスク作成モーダルで既存タグを選択・解除できる
- [ ] タスク作成モーダルでタグ名入力→カラー選択→新規タグ作成できる
- [ ] 作成したタスクにタグが紐付いてTaskCardにバッジ表示される
- [ ] タスク編集モーダルで既存のタグ付与状態が正しく表示される
- [ ] タスク編集モーダルでタグの追加・削除ができる
- [ ] 同名タグの作成時にエラーメッセージが表示される

Closes #10