### PR TITLE
feat: タスク期限日（due date）機能

### DIFF
--- a/src/app/(dashboard)/projects/[projectId]/actions.ts
+++ b/src/app/(dashboard)/projects/[projectId]/actions.ts
@@ -19,6 +19,10 @@ const createTaskSchema = z.object({
     .transform((val) => val || null),
   status: z.enum(["todo", "in_progress", "done"]).default("todo"),
   priority: z.enum(["low", "medium", "high"]).default("medium"),
+  due_date: z
+    .string()
+    .optional()
+    .transform((val) => val || null),
 });
 
 const updateTaskSchema = z.object({
@@ -33,6 +37,10 @@ const updateTaskSchema = z.object({
     .transform((val) => val || null),
   status: z.enum(["todo", "in_progress", "done"]),
   priority: z.enum(["low", "medium", "high"]),
+  due_date: z
+    .string()
+    .optional()
+    .transform((val) => val || null),
 });
 
 const createTagSchema = z.object({
@@ -52,6 +60,7 @@ export interface CreateTaskState {
     description?: string[];
     status?: string[];
     priority?: string[];
+    due_date?: string[];
   };
   success?: boolean;
   taskId?: string;
@@ -64,6 +73,7 @@ export interface UpdateTaskState {
     description?: string[];
     status?: string[];
     priority?: string[];
+    due_date?: string[];
   };
   success?: boolean;
 }
@@ -105,6 +115,7 @@ export async function createTask(
     description: formData.get("description") as string,
     status: formData.get("status") as string,
     priority: formData.get("priority") as string,
+    due_date: formData.get("due_date") as string,
   };
 
   const validatedFields = createTaskSchema.safeParse(rawFormData);
@@ -135,6 +146,7 @@ export async function createTask(
         description: validatedFields.data.description,
         status: validatedFields.data.status,
         priority: validatedFields.data.priority,
+        due_date: validatedFields.data.due_date,
         project_id: projectId,
         created_by: user.id,
       })
@@ -171,6 +183,7 @@ export async function updateTask(
     description: formData.get("description") as string,
     status: formData.get("status") as string,
     priority: formData.get("priority") as string,
+    due_date: formData.get("due_date") as string,
   };
 
   const validatedFields = updateTaskSchema.safeParse(rawFormData);
@@ -201,6 +214,7 @@ export async function updateTask(
         description: validatedFields.data.description,
         status: validatedFields.data.status,
         priority: validatedFields.data.priority,
+        due_date: validatedFields.data.due_date,
       })
       .eq("id", taskId);
 

--- a/src/components/tasks/CreateTaskModal.tsx
+++ b/src/components/tasks/CreateTaskModal.tsx
@@ -197,6 +197,26 @@ export default function CreateTaskModal({
                 </div>
               </div>
 
+              <div>
+                <label
+                  htmlFor="create-task-due-date"
+                  className="block text-sm font-medium text-gray-700"
+                >
+                  期限日（任意）
+                </label>
+                <input
+                  type="date"
+                  id="create-task-due-date"
+                  name="due_date"
+                  className="mt-1 block w-full rounded-lg border border-gray-300 px-3 py-2 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+                />
+                {state.fieldErrors?.due_date?.[0] && (
+                  <p className="mt-1 text-sm text-red-600">
+                    {state.fieldErrors.due_date[0]}
+                  </p>
+                )}
+              </div>
+
               <TagSelector
                 projectId={projectId}
                 availableTags={localTags}

--- a/src/components/tasks/EditTaskModal.tsx
+++ b/src/components/tasks/EditTaskModal.tsx
@@ -180,6 +180,27 @@ export default function EditTaskModal({
             </div>
           </div>
 
+          <div>
+            <label
+              htmlFor="edit-task-due-date"
+              className="block text-sm font-medium text-gray-700"
+            >
+              期限日（任意）
+            </label>
+            <input
+              type="date"
+              id="edit-task-due-date"
+              name="due_date"
+              defaultValue={task.due_date?.split("T")[0] ?? ""}
+              className="mt-1 block w-full rounded-lg border border-gray-300 px-3 py-2 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+            />
+            {state.fieldErrors?.due_date?.[0] && (
+              <p className="mt-1 text-sm text-red-600">
+                {state.fieldErrors.due_date[0]}
+              </p>
+            )}
+          </div>
+
           <TagSelector
             projectId={projectId}
             availableTags={localTags}

--- a/src/components/tasks/TaskCard.tsx
+++ b/src/components/tasks/TaskCard.tsx
@@ -31,6 +31,36 @@ const priorityColors: Record<TaskPriority, string> = {
   high: "border-red-500 text-red-600",
 };
 
+type DueDateStatus = "overdue" | "today" | "upcoming";
+
+function getDueDateStatus(dueDate: string | null): DueDateStatus | null {
+  if (!dueDate) return null;
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  const due = new Date(dueDate + "T00:00:00");
+
+  if (due < today) return "overdue";
+  if (due.getTime() === today.getTime()) return "today";
+  return "upcoming";
+}
+
+function formatDueDate(dueDate: string): string {
+  const due = new Date(dueDate + "T00:00:00");
+  return due.toLocaleDateString("ja-JP", { month: "numeric", day: "numeric" });
+}
+
+const dueDateStyles: Record<DueDateStatus, string> = {
+  overdue: "bg-red-50 text-red-600 border border-red-200",
+  today: "bg-yellow-50 text-yellow-600 border border-yellow-200",
+  upcoming: "bg-gray-50 text-gray-600 border border-gray-200",
+};
+
+const dueDateLabels: Record<DueDateStatus, (formatted: string) => string> = {
+  overdue: (d) => `期限切れ: ${d}`,
+  today: () => "今日まで",
+  upcoming: (d) => `${d}まで`,
+};
+
 interface TaskCardProps {
   task: TaskWithTags;
   projectId: string;
@@ -45,6 +75,8 @@ export default function TaskCard({
   const [showEdit, setShowEdit] = useState(false);
   const [showDelete, setShowDelete] = useState(false);
 
+  const dueDateStatus = getDueDateStatus(task.due_date);
+
   return (
     <>
       <div className="flex items-center gap-4 rounded-lg bg-white p-4 shadow-sm">
@@ -55,13 +87,18 @@ export default function TaskCard({
               {task.description}
             </p>
           )}
-          {task.tags.length > 0 && (
-            <div className="mt-2 flex flex-wrap gap-1">
-              {task.tags.map((tag) => (
-                <TagBadge key={tag.id} tag={tag} size="sm" />
-              ))}
-            </div>
-          )}
+          <div className="mt-2 flex flex-wrap items-center gap-1">
+            {dueDateStatus && task.due_date && (
+              <span
+                className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${dueDateStyles[dueDateStatus]}`}
+              >
+                {dueDateLabels[dueDateStatus](formatDueDate(task.due_date))}
+              </span>
+            )}
+            {task.tags.map((tag) => (
+              <TagBadge key={tag.id} tag={tag} size="sm" />
+            ))}
+          </div>
         </div>
 
         <span


### PR DESCRIPTION
## 概要
タスクに期限日を設定・表示し、期限の状態に応じて視覚的フィードバックを提供する機能を追加。

## 変更点
- Server Actions（create/update）に `due_date` フィールドを追加（Zod バリデーション付き）
- タスク作成・編集モーダルにネイティブ日付ピッカー（`<input type="date">`）を追加
- タスクカードに期限日バッジを表示（期限切れ: 赤、今日: 黄、通常: グレー）

## テストプラン

### エージェント確認済み
- [x] ESLint: エラーなし
- [x] TypeScript / ビルド: 成功
- [x] セキュリティチェック: 秘匿情報・個人情報の混入なし

### 手動確認（マージ前にユーザーが実施）
- [ ] タスク作成時に期限日を設定 → カードに期限バッジが表示される
- [ ] タスク作成時に期限日なしで作成 → バッジが表示されない
- [ ] タスク編集で期限日を変更 → バッジが更新される
- [ ] タスク編集で期限日をクリア → バッジが消える
- [ ] 過去日付のタスク → 赤色の「期限切れ: M/D」バッジ
- [ ] 今日の日付のタスク → 黄色の「今日まで」バッジ
- [ ] 未来の日付のタスク → グレーの「M/Dまで」バッジ
- [ ] 既存機能（タグ、ステータス、優先度）が正常に動作する

Closes #15